### PR TITLE
Simply the Field.toProps

### DIFF
--- a/src/fields.js
+++ b/src/fields.js
@@ -31,12 +31,12 @@ export class Field {
     /**
      * Returns a plain object of props for the field.
      *
-     * @param {Component} form The form component that wraps the value
+     * @param {string} name The name of the field in the form.
      * @param {func} changeHandler The change handler 
      * @param {mixed} currentValue the current value of the field
      * @return {function} A function that can be called to render the props for the fields.
      */
-    toProps(form, changeHandler, currentValue) {
+    toProps(name, changeHandler, currentValue) {
         return () => {
             return {};
         };
@@ -47,11 +47,11 @@ export class Field {
      * this works will depend on the the field. Checkboxes will be different
      * from text inputs, for instance.
      *
-     * @param {Component} form The react component
+     * @param {string} name The name of the field in the form
      * @param {func(newValue)} updateValue A function that takes the new value for the field
      * @return {func(event, currentValue)}
      */
-    createChangeHandler(form, updateValue) {
+    createChangeHandler(name, updateValue) {
         return (event, currentValue) => { };
     }
 
@@ -99,16 +99,17 @@ export class Field {
  * check boxes
  */
 export class SimpleField extends Field {
-    toProps(form, changeHandler, currentValue) {
+    toProps(name, changeHandler, currentValue) {
         return () => {
             return {
                 value: currentValue,
                 onChange: changeHandler,
+                name,
             };
         };
     }
 
-    createChangeHandler(form, updateValue) {
+    createChangeHandler(name, updateValue) {
         return event => {
             updateValue(event.target.value);
         };
@@ -119,18 +120,19 @@ export class SimpleField extends Field {
  * A field object suitable for use with checkboxes.
  */
 export class Checkbox extends Field {
-    toProps(form, changeHandler, currentValue) {
+    toProps(name, changeHandler, currentValue) {
         return (value) => {
             let cv = this.filterInput(currentValue);
             return {
                 checked: !!cv.checked,
                 onChange: changeHandler,
                 value: typeof value === 'undefined' ? cv.value : value,
+                name,
             };
         };
     }
 
-    createChangeHandler(form, updateValue) {
+    createChangeHandler(name, updateValue) {
         return (event, currentValue) => {
             let cv = this.filterInput(currentValue);
             updateValue({
@@ -172,7 +174,7 @@ export class Checkbox extends Field {
  * A field suitable for radio buttons.
  */
 export class Radio extends SimpleField {
-    toProps(form, changeHandler, currentValue) {
+    toProps(name, changeHandler, currentValue) {
         return fieldValue => {
             invariant(typeof fieldValue !== 'undefined', 'You must supply a field value to radio field toProps');
 
@@ -180,6 +182,7 @@ export class Radio extends SimpleField {
                 checked: fieldValue === currentValue,
                 onChange: changeHandler,
                 value: fieldValue,
+                name,
             };
         };
     }

--- a/src/form.js
+++ b/src/form.js
@@ -182,16 +182,11 @@ export default function higherform(fieldSpec, formSpec) {
             }
 
             _buildFieldProps(field) {
-                return (...args) => {
-                    let props = this.fields[field].toProps(
-                        this,
-                        this.changeHandlers[field],
-                        this.state[field]
-                    )(...args);
-                    props.name = field;
-
-                    return props;
-                };
+                return this.fields[field].toProps(
+                    field,
+                    this.changeHandlers[field],
+                    this.state[field],
+                );
             }
 
             _configureFields(props) {

--- a/test/fields.spec.js
+++ b/test/fields.spec.js
@@ -1,6 +1,8 @@
 import { fields } from '../src';
 
 describe('fields', function () {
+    const name = 'example';
+
     describe('#Field', function () {
         it('should error when given validators that are not functions', function () {
             assert.throws(() => {
@@ -42,7 +44,7 @@ describe('fields', function () {
         it('returns a change handler that updates the form will a value from the event', function () {
             let value = null;
             let updateValue = v => value = v;
-            let onChange = field.createChangeHandler({}, updateValue);
+            let onChange = field.createChangeHandler(name, updateValue);
 
             onChange({target: {value: 'test'}}, value);
 
@@ -53,11 +55,12 @@ describe('fields', function () {
             let onChange = () => {};
             let value = 'test';
 
-            let props = field.toProps({}, onChange, value)();
+            let props = field.toProps(name, onChange, value)();
 
             assert.deepEqual(props, {
                 value,
                 onChange,
+                name,
             });
         });
     });
@@ -68,7 +71,7 @@ describe('fields', function () {
         it('should return a change handler that sets checked and the target value', function () {
             let value = null;
             let updateValue = v => value = v;
-            let onChange = field.createChangeHandler({}, updateValue);
+            let onChange = field.createChangeHandler(name, updateValue);
 
             onChange({target: {value: 'test'}}, {});
 
@@ -83,12 +86,13 @@ describe('fields', function () {
                 let checked = true;
                 let onChange = () => { };
 
-                let props = field.toProps({}, onChange, {checked})();
+                let props = field.toProps(name, onChange, {checked})();
 
                 assert.deepEqual(props, {
                     checked,
                     onChange,
                     value: '1',
+                    name,
                 });
             });
 
@@ -96,12 +100,13 @@ describe('fields', function () {
                 let checked = false;
                 let onChange = () => { };
 
-                let props = field.toProps({}, onChange)();
+                let props = field.toProps(name, onChange)();
 
                 assert.deepEqual(props, {
                     checked,
                     onChange,
                     value: '1',
+                    name,
                 });
             });
 
@@ -110,12 +115,13 @@ describe('fields', function () {
                 let onChange = () => { };
                 let value = 'yep';
 
-                let props = field.toProps({}, onChange)(value);
+                let props = field.toProps(name, onChange)(value);
 
                 assert.deepEqual(props, {
                     checked,
                     onChange,
                     value,
+                    name,
                 });
             });
         });
@@ -194,12 +200,13 @@ describe('fields', function () {
 
         it('should return props with checked set to whether or not the current value is equal to the field', function () {
             let onChange = () => {};
-            let props = field.toProps({}, onChange, 'test')('test');
+            let props = field.toProps(name, onChange, 'test')('test');
 
             assert.deepEqual(props, {
                 checked: true,
                 value: 'test',
                 onChange,
+                name,
             });
         });
     });


### PR DESCRIPTION
Pass in the field name so fields themselves can choose to include it or
not. This also removes a level of indirection from the form (not a bad
thing).

Foundational work for collections (#5) and nested fields (#4).