### PR TITLE
Add a Way to Programmatically Update Field Values

### DIFF
--- a/src/fields/Collection.js
+++ b/src/fields/Collection.js
@@ -63,6 +63,8 @@ export default class Collection {
 
                 return out;
             },
+
+            setValue: value => updateValue(this.filterInput(value)),
         };
 
         for (let m of Object.keys(this.field.toMethods(name, updateValue, getValue))) {

--- a/src/fields/Field.js
+++ b/src/fields/Field.js
@@ -35,6 +35,7 @@ export default class Field {
      */
     toMethods(name, updateValue, getValue) {
         return {
+            setValue: value => updateValue(this.filterInput(value)),
             props: this._buildPropsMethod(name, updateValue, getValue),
         };
     }

--- a/src/fields/Shape.js
+++ b/src/fields/Shape.js
@@ -41,6 +41,8 @@ export default class Collection {
                 return methodsFor(field).props(...args);
             },
 
+            setValue: value => updateValue(this.filterInput(value)),
+
             methodsFor: methodsFor,
         };
     }

--- a/test/fields/Collection.spec.js
+++ b/test/fields/Collection.spec.js
@@ -154,5 +154,23 @@ describe('fields/Collection', function () {
                 assert.lengthOf(tf.toMethodsCalls, 4, 'should have made three calls for the map, 1 for collection field toMethods');
             });
         });
+
+        describe('#setValue', function () {
+            it('should set the input to an empty array when the value is undefined', function () {
+                buildMethods().setValue(void 0);
+
+                assert.lengthOf(updatedValues, 1, 'should have updated the values once');
+                assert.deepEqual([], updatedValues[0]);
+            });
+
+            it('should set the input to the value provided', function () {
+                buildMethods().setValue(['one']);
+
+                assert.lengthOf(updatedValues, 1, 'should have updated the values once');
+                assert.deepEqual(['one'], updatedValues[0]);
+                assert.lengthOf(tf.filterInputCalls, 1);
+                assert.equal('one', tf.filterInputCalls[0]);
+            });
+        })
     });
 });

--- a/test/fields/Field.spec.js
+++ b/test/fields/Field.spec.js
@@ -77,4 +77,27 @@ describe('fields/Field', function () {
             assert.equal(value, 'test');
         });
     });
+
+    describe('#toMethods(setValue)', function () {
+        const field = new fields.Field();
+        const name = 'example';
+
+        it('should update the value via the updateValue callback', function () {
+            let value = 'initial';
+            let updateValue = v => value = v;
+
+            field.toMethods(name, updateValue, () => value).setValue('changed');
+
+            assert.equal(value, 'changed');
+        });
+
+        it('should set the value to an empty string when its empty', function () {
+            let value = 'initial';
+            let updateValue = v => value = v;
+
+            field.toMethods(name, updateValue, () => value).setValue(null);
+
+            assert.equal(value, '');
+        });
+    });
 });

--- a/test/fields/Shape.spec.js
+++ b/test/fields/Shape.spec.js
@@ -115,5 +115,19 @@ describe('fields/Shape', function () {
                 assert.deepEqual(updatedValues[0](values), Object.assign({}, values, {[subName]: 'changed'}));
             });
         });
+
+        describe('#setValue', function () {
+            it('should proxy to the update value callback after filtering the input', function () {
+                buildMethods().setValue({
+                    [subName]: 'changed',
+                });
+
+                assert.lengthOf(updatedValues, 1);
+                assert.deepEqual([{
+                    [subName]: 'changed',
+                    other: '',
+                }], updatedValues);
+            });
+        });
     });
 });


### PR DESCRIPTION
All fields now have a `setValue` method, so the wrapped form components
can do something like this:

    this.props.fields.aField.setValue('newValue')

Closes #12