### PR TITLE
Updates submit functionality and tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "higherform",
     "description": "A ReactJS form library built around higher order components",
     "main": "./lib/index.js",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "license": "MIT",
     "scripts": {
         "test": "mocha --compilers js:babel-register --recursive --require ./test/setup.js",

--- a/src/form.js
+++ b/src/form.js
@@ -118,8 +118,8 @@ export default function higherform(fieldSpec, formSpec) {
              * Validate the form, and if it's good to go, call the `submit` callback
              * with the form data object.
              *
-             * @param {func(formData)} submit the callback to "sumbit" the form data.
-             * @return void
+             * @param {func(errors, formData)} submit the callback to "sumbit" the form data.
+             * @return a Promise that resolves with formData and rejects with errors.
              */
             submit(callback) {
                 let toSubmit = {};
@@ -141,17 +141,14 @@ export default function higherform(fieldSpec, formSpec) {
                     __errors: errors,
                 });
 
-                // if the callback has two or more parameters, then assume
-                // it is the normal JS error callback. so call it appropriately
-                // with errors.
-                if (callback.length >= 2) {
+                if (callback) {
                     callback(hasErrors ? errors : void 0, hasErrors ? void 0 : toSubmit);
-                    return;
                 }
 
-                if (!hasErrors) {
-                    callback(toSubmit);
+                if (hasErrors) {
+                    return Promise.reject(errors);
                 }
+                return Promise.resolve(toSubmit);
             }
 
             buildFields() {

--- a/src/form.js
+++ b/src/form.js
@@ -141,6 +141,14 @@ export default function higherform(fieldSpec, formSpec) {
                     __errors: errors,
                 });
 
+                // if the callback has two or more parameters, then assume
+                // it is the normal JS error callback. so call it appropriately
+                // with errors.
+                if (callback.length >= 2) {
+                    callback(hasErrors ? errors : void 0, hasErrors ? void 0 : toSubmit);
+                    return;
+                }
+
                 if (!hasErrors) {
                     callback(toSubmit);
                 }

--- a/test/form.spec.js
+++ b/test/form.spec.js
@@ -82,6 +82,43 @@ describe('form', function () {
             assert.deepEqual(submitted, {example: 'changed'});
         });
 
+        it('should call the submit callback with errors and undefined if length 2 or more', function (done) {
+            const submit = function(errors, formData) {
+                assert.deepEqual(errors, {example: ['oops']});
+                assert.isUndefined(formData);
+                done();
+            };
+
+            const FieldSpec = {
+                example: fields.input(function(_, ctx) {
+                    ctx.addViolation('oops');
+                }),
+            };
+            const Form = higherform(FieldSpec)(BasicForm);
+            const tree = TestUtils.renderIntoDocument(<Form submit={submit} />);
+
+            submitForm(tree);
+        });
+
+        it('should call the submit callback with undefined and formData if length 2 or more', function (done) {
+            const submit = function(errors, formData) {
+                assert.isUndefined(errors);
+                assert.deepEqual(formData, {example: 'changed'});
+                done();
+            };
+
+            const FieldSpec = {
+                example: fields.input(),
+            };
+            const Form = higherform(FieldSpec)(BasicForm);
+            const tree = TestUtils.renderIntoDocument(<Form submit={submit} />);
+
+            changeInput(tree, {
+                target: {value: 'changed'},
+            });
+            submitForm(tree);
+        });
+
         it('should update the view with errors when the form fails to validate', function () {
             const FieldSpec = {
                 example: fields.input(function (currentValue, ctx) {


### PR DESCRIPTION
This allows you to give a normal javascript `callback(error, value)` callback and always have the function called instead of only when validation passes.

This is useful for situations where there are multiple, independent higherform components that you want to validate all at once and not in succession when the prior is validated. 
